### PR TITLE
Add more existing solution refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ const {
 
 http://bluebirdjs.com/docs/api/promise.props.html
 
+https://github.com/slorber/combine-promises
+
+https://github.com/sindresorhus/p-props
+
 ## Implementations
 
 ### Polyfill/transpiler implementations


### PR DESCRIPTION

Quite similar to bluebird p-props anyway

In case it's helpful: the name "combine-promise" is inspired from "combineReducers" of Redux: https://redux.js.org/api/combinereducers